### PR TITLE
RSS import improvements

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -27,5 +27,97 @@
         "consumer_secret":      "secret",
         "access_token":         "token-secret",
         "access_token_secret":  "token-secret"
+    },
+
+    "chargebee": {
+        "site":         "",
+        "api_key":      "secret",
+        "redirect_url": ""
+    },
+
+    "rss_presets": {
+        "news": {
+            "id": "news",
+            "name": "News of the Day",
+            "urls": [
+              "https://www.theguardian.com/world/rss",
+              "http://www.wsj.com/xml/rss/3_7085.xml",
+              "http://rss.nytimes.com/services/xml/rss/nyt/World.xml",
+              "http://feeds.washingtonpost.com/rss/world",
+              "https://www.ft.com/?format=rss"
+            ],
+            "items": 15
+        },
+        "guardian": {
+            "id":   "guardian",
+            "name": "The Guardian RSS",
+            "urls": ["https://www.theguardian.com/rss"],
+            "items": 20
+        },
+        "ft": {
+            "id":   "ft",
+            "name": "FT.Com RSS",
+            "urls": ["https://www.ft.com/?format=rss"],
+            "items": 20
+        },
+        "wsj": {
+            "id":   "wsj",
+            "name": "Wall Street Journal RSS",
+            "urls": ["http://www.wsj.com/xml/rss/3_7085.xml"],
+            "items": 10
+        },
+        "nyt": {
+            "id":   "nyt",
+            "name": "New York Times RSS",
+            "urls": ["http://rss.nytimes.com/services/xml/rss/nyt/World.xml"],
+            "items": 20
+        },
+        "french": {
+            "id":   "french",
+            "name": "France News RSS",
+            "urls": [
+              "http://www.lemonde.fr/rss/une.xml",
+              "http://www.bfmtv.com/rss",
+              "http://www.lefigaro.fr/rss/figaro_actualites.xml",
+              "http://rss.liberation.fr/rss/latest/",
+              "http://www.leparisien.fr/une/rss.xml"
+            ],
+            "items": 15
+        },
+        "russian": {
+            "id":   "russian",
+            "name": "Russian News RSS",
+            "urls": [
+              "https://www.vedomosti.ru/rss/news",
+              "https://meduza.io/rss/all",
+              "http://static.feed.rbc.ru/rbc/logical/footer/news.rss",
+              "https://russian.rt.com/rss",
+              "https://lenta.ru/rss"
+            ],
+            "items": 15
+        },
+        "german": {
+            "id":   "german",
+            "name": "German News RSS",
+            "urls": [
+              "http://www.faz.net/rss/aktuell/",
+              "http://rss.sueddeutsche.de/app/service/rss/alles/index.rss?output=rss",
+              "https://www.welt.de/feeds/latest.rss",
+              "https://www.tagesspiegel.de/contentexport/feed/home",
+              "http://www.taz.de/!p15;rss/"
+            ],
+            "items": 15
+        },
+        "tech": {
+            "id":   "tech",
+            "name": "Tech News RSS",
+            "urls": [
+              "http://feeds.feedburner.com/TechCrunch",
+              "https://www.technologyreview.com/topnews.rss",
+              "http://feeds.arstechnica.com/arstechnica/technology-lab",
+              "http://feeds.feedburner.com/venturebeat/SZYF"
+            ],
+            "items": 15
+        }
     }
 }

--- a/options.js
+++ b/options.js
@@ -84,10 +84,11 @@ if (fs.existsSync(configPath)) {
     exports.default_user = parsed['infranodus']['default_user']
 
     exports.chargebee = parsed['chargebee']
-
     exports.chargebee.site = parsed['chargebee']['site']
     exports.chargebee.api_key = parsed['chargebee']['api_key']
     exports.chargebee.redirect_url = parsed['chargebee']['redirect_url']
+
+    exports.rssPresets = parsed['rss_presets']
 } else {
     console.log("Neo4J config file doesn't exist. Using default settings.")
 

--- a/routes/imports.js
+++ b/routes/imports.js
@@ -227,6 +227,7 @@ exports.renderRSS = function(req, res) {
         context: req.query.context,
         contextlist: contextslist,
         notebooks: '',
+        rsspresets: options.rssPresets,
         fornode: req.query.fornode,
     })
 }
@@ -1491,8 +1492,8 @@ exports.submit = function(req, res, next) {
             req.files.uploadedFile.size < max_total_length &&
             (filetype == 'text/html' ||
                 filetype == 'text/plain' ||
-                filetype == 'application/pdf' ||  
-                filetype == 'application/octet-stream' ||                
+                filetype == 'application/pdf' ||
+                filetype == 'application/octet-stream' ||
                 filetype == 'text/csv')
         ) {
             // Import parameters
@@ -1719,24 +1720,24 @@ exports.submit = function(req, res, next) {
                                 if (gexf_nodes[j].id == gexf_edges[i].target) {
                                     if (!gexf_statements[i]) gexf_statements[i] = ' ';
                                     gexf_statements[i] += ' #' + S(gexf_nodes[j].label.toLowerCase()).underscore();
-                                } 
-                            } 
+                                }
+                            }
                             if (gexf_edges[i].weight > 1) {
                                 for (let k = 0; k < gexf_edges[i].weight; k++) {
-                                    gexf_statements[i] += '\n\n ' + gexf_statements[i]; 
+                                    gexf_statements[i] += '\n\n ' + gexf_statements[i];
                                 }
-                            }                           
+                            }
                         }
-                     
+
                         //console.log(gexf_statements);
 
-                    
+
                         var currentcontext = processContext(importContext)
 
                         parsedata[currentcontext] = [];
 
                         parsedata[currentcontext].push(gexf_statements.join('\n\n'));
-                        
+
                         processFile(
                             titlefield,
                             processfield,
@@ -2021,7 +2022,7 @@ exports.submit = function(req, res, next) {
                                                 )
                                                 something_added += 1
                                             }
-                                        
+
                                         }
                                     }
                                 }
@@ -2346,6 +2347,9 @@ exports.submit = function(req, res, next) {
 
         var rssItemsMax = validate.sanitize(req.body.rssitems)
 
+        // If no date given, default to a very old date to allow all articles through
+        var rssSinceDateTime = (!!req.body.rsssince ? Date.parse(req.body.rsssince) : Date.parse("1970-01-01"))
+
         var includeteasers = validate.sanitize(req.body.includeteasers)
 
         var statements = []
@@ -2399,7 +2403,7 @@ exports.submit = function(req, res, next) {
                             var rssIterations = 0
 
                             items.forEach(itemo => {
-                                if (rssIterations < limito) {
+                                if (rssIterations < limito && itemo.pubdate >= rssSinceDateTime) {
                                     var thisheadline = S(
                                         itemo.title
                                     ).stripTags().s
@@ -2799,7 +2803,7 @@ exports.submit = function(req, res, next) {
                     walkthrough: walknext
                 }
 
-                
+
                 let google_request_link = config.google.URL_search + config.google.API_key + '&q=' + searchString.toLowerCase();
 
                 https.get(google_request_link, (resp) => {
@@ -2817,12 +2821,12 @@ exports.submit = function(req, res, next) {
                         let googlejson = JSON.parse(receiveddata);
 
                         req.body.entry.body = addGoogleEntry(googlejson, excludetitles);
-                        
+
                         let currentmarker = 0;
 
                         // How much total results we get?
                         let tot_search_results = googlejson.queries.request[0].totalResults;
-                        
+
                         currentmarker = tot_search_results - 10;
 
                         let startmarker = 0;
@@ -2836,10 +2840,10 @@ exports.submit = function(req, res, next) {
                                 resp.on('data', (chunk) => {
                                     receiveddata += chunk;
                                 });
-            
+
                                 // The whole response has been received. Print out the result.
                                 resp.on('end', () => {
-                                    
+
                                     googlejson = JSON.parse(receiveddata);
 
                                     req.body.entry.body = req.body.entry.body.concat(addGoogleEntry(googlejson, excludetitles));
@@ -2856,16 +2860,16 @@ exports.submit = function(req, res, next) {
                                             resp.on('data', (chunk) => {
                                                 receiveddata += chunk;
                                             });
-                        
+
                                             // The whole response has been received. Print out the result.
                                             resp.on('end', () => {
-                                                
+
                                                 googlejson = JSON.parse(receiveddata);
-            
+
                                                 req.body.entry.body = req.body.entry.body.concat(addGoogleEntry(googlejson, excludetitles));
-            
+
                                                 currentmarker = tot_search_results - 30;
-            
+
                                                 if (currentmarker > 0) {
                                                     startmarker = 30;
 
@@ -2876,12 +2880,12 @@ exports.submit = function(req, res, next) {
                                                         resp.on('data', (chunk) => {
                                                             receiveddata += chunk;
                                                         });
-                                    
+
                                                         // The whole response has been received. Print out the result.
                                                         resp.on('end', () => {
-                                                            
+
                                                             googlejson = JSON.parse(receiveddata);
-                        
+
                                                             req.body.entry.body = req.body.entry.body.concat(addGoogleEntry(googlejson, excludetitles));
 
 
@@ -2894,7 +2898,7 @@ exports.submit = function(req, res, next) {
                                                                 let searchlemmas = [];
 
                                                                 for (let k = 0; k < searchterms.length; k++) {
-                                                                
+
                                                                     // Now we find lemmas, so we deal with plural cases and also with Russian word endings and suffixes
                                                                     // TODO this whole thing should be moved outside of this function and Russian lemmas should be added to stopwords not deleted from text
 
@@ -2904,7 +2908,7 @@ exports.submit = function(req, res, next) {
                                                                     ) {
                                                                         var lemmaterm = lemmerRus.lemmatize(
                                                                             searchterms[k]
-                                                                        ) 
+                                                                        )
                                                                     }
 
                                                                     // English?
@@ -2912,33 +2916,33 @@ exports.submit = function(req, res, next) {
                                                                         var lemmaterm = lemmerEng.lemmatize(
                                                                             searchterms[k]
                                                                         )
-                                                                    
+
                                                                     }
-                                                                    
+
                                                                     // Now push the lemma into the list
                                                                     if (lemmaterm[0] != undefined) {
                                                                         searchlemmas.push(lemmaterm[0].toLowerCase())
                                                                     }
                                                                 }
 
-                                                                req.excludestopwords = searchlemmas; 
+                                                                req.excludestopwords = searchlemmas;
                                                             }
 
                                                             // Submit entries (routes/entries.js)
-                        
+
                                                             entries.submit(req, res);
 
-                        
+
                                                         });
                                                     });
-                                                    
+
                                                 }
                                                 else {
                                                     entries.submit(req, res);
 
                                                 }
-            
-            
+
+
                                             });
                                         });
 
@@ -2962,13 +2966,13 @@ exports.submit = function(req, res, next) {
                             }
                         }
 
-                       
+
 
 
 
                     });
 
-            
+
 
                 }).on("error", (err) => {
                     console.log("Error: " + err.message);
@@ -2991,7 +2995,7 @@ exports.submit = function(req, res, next) {
             let searchresults = googlejson.items;
 
             if (searchresults) {
-                for (let i = 0; i < searchresults.length;  ++i) { 
+                for (let i = 0; i < searchresults.length;  ++i) {
                     if (
                         searchresults[i].snippet &&
                         searchresults[i].snippet != 'null' &&

--- a/views/importrss.ejs
+++ b/views/importrss.ejs
@@ -21,9 +21,6 @@
 
     <%- include('components/common/menu') %>
 
-
-
-
     <div id='content'>
 
         <div id='welcomemessage'>
@@ -38,47 +35,42 @@
                     <input type="hidden" name="source" value="rss">
 
                     <select name="urlselect" id="urlselect">
-                      <option value="news" selected>News of the Day</option>
-                      <option value="guardian">The Guardian RSS</option>
-                      <option value="ft">FT.Com RSS</option>
-                      <option value="wsj">Wall Street Journal RSS</option>
-                      <option value="nyt">New York Times RSS</option>
-                      <option value="french">France News RSS</option>
-                      <option value="russian">Russian News RSS</option>
-                      <option value="german">German News RSS</option>
-                      <option value="tech">Tech News RSS</option>
                       <option value="custom">Custom RSS feeds</option>
+                      <% for (var item in rsspresets) { %>
+                        <option value="<%= rsspresets[item]['id'] %>"><%= rsspresets[item]['name'] %></option>
+                      <% } %>
                     </select>
                     <br>
-                    <a href="javascript:" id="advancedpane">+ settings</a>
+                    <a href="javascript:" id="advancedpane">- settings</a>
                     <br>
                     <div id="urlsetting">
                       <br>
                         RSS feeds to be visualized:
-                        <textarea id="rssinput" name="rssinput" rows="4" cols="20">https://www.theguardian.com/world/rss http://www.wsj.com/xml/rss/3_7085.xml http://rss.nytimes.com/services/xml/rss/nyt/World.xml http://feeds.washingtonpost.com/rss/world https://www.ft.com/?format=rss</textarea>
+                        <textarea id="rssinput" name="rssinput" rows="4" cols="20">
+                        </textarea>
                         <br>
                         <label for="rssitems" class="pure-input" id="rssitemscaption">
                             # of items for each feed:
                             <input type="text" name="rssitems" id="rssitems" value="15"/>
                         </label>
                         <br>
+                        <label for="rsssince" class="pure-input" id="rsssincecaption">
+                            Limit items in each feed to those later than a date & time (optional):
+                            <input type="text" name="rsssince" id="rsssince" value="" placeholder="YYYY-MM-DD HH:MI"/>
+                        </label>
+                        <br>
                         <label for="includeteasers" class="pure-checkbox">
-                                <input id="includeteasers" type="checkbox" name="includeteasers" value="1"> include teasers
-
+                            <input id="includeteasers" type="checkbox" name="includeteasers" value="1"> include teasers
                         </label>
                         <br>
 
                     </div>
-
-
-
 
                 <br>
                 Save in Context:
                 <br>
                 <input type='text' name='context' id="context" value='<% if (context) { %><%= context %><% } else { %>news<% } %>'/>
                 <br>
-
 
                 <input type="hidden" id="selectedContexts" name="selectedContexts" value="">
                 <input type="hidden" name="statementid" value="">
@@ -89,19 +81,11 @@
 
             </form>   &nbsp;<br>&nbsp;<br>
 
-
-
-
-
         </div>
 
         <div id="graph-container"></div>
 
-
     </div>
-
-
-
 
 </div>
 
@@ -124,112 +108,49 @@
 
           $('#context').val('news' + nowdate);
 
-          var advancedpane = 0;
+          var advancedpane = 1;
 
-          $("#advancedsettings").hide();
-          $('#urlsetting').hide();
+          var clientRssPresets = JSON.parse('<%- JSON.stringify(rsspresets) %>');
 
           $("#advancedpane").click(function() {
               if (!advancedpane) {
-          //    $("#advancedsettings").show();
-              $("#advancedpane").text('– settings');
-              $("#urlsetting").show();
-              advancedpane = 1;
+                  $("#advancedpane").text('– settings');
+                  $("#urlsetting").show();
+                  advancedpane = 1;
               }
               else {
-            //  $("#advancedsettings").hide();
-              $("#advancedpane").text('+ settings');
-              $("#urlsetting").hide();
-              advancedpane = 0;
-
+                  $("#advancedpane").text('+ settings');
+                  $("#urlsetting").hide();
+                  advancedpane = 0;
               }
-
           });
 
           $('#urlselect').change(function () {
-
-
             var currentselection = $(this).val();
             $('#context').val(currentselection + nowdate);
 
-            if (currentselection == 'news') {
-              $('#rssinput').val('https://www.theguardian.com/world/rss http://www.wsj.com/xml/rss/3_7085.xml http://rss.nytimes.com/services/xml/rss/nyt/World.xml http://feeds.washingtonpost.com/rss/world https://www.ft.com/?format=rss');
-              $("#rssitems").val('15');
-            }
-            else if (currentselection == 'guardian') {
-              $('#rssinput').val('https://www.theguardian.com/rss');
-              $("#urlsetting").show();
-              $("#rssitems").val('20');
-              $("#advancedpane").text('– settings');
-              advancedpane = 1;
-            }
-            else if (currentselection == 'ft') {
-              $('#rssinput').val('https://www.ft.com/?format=rss');
-              $("#urlsetting").show();
-              $("#rssitems").val('20');
-              $("#advancedpane").text('– settings');
-              advancedpane = 1;
-            }
-            else if (currentselection == 'wsj') {
-              $('#rssinput').val('http://www.wsj.com/xml/rss/3_7085.xml');
-              $("#urlsetting").show();
-              $("#rssitems").val('10');
-              $("#advancedpane").text('– settings');
-              advancedpane = 1;
-            }
-            else if (currentselection == 'nyt') {
-              $('#rssinput').val('http://rss.nytimes.com/services/xml/rss/nyt/World.xml');
-              $("#urlsetting").show();
-              $("#rssitems").val('20');
-              $("#advancedpane").text('– settings');
-              advancedpane = 1;
-            }
-            else if (currentselection == 'french') {
-              $('#rssinput').val('http://www.lemonde.fr/rss/une.xml  http://www.bfmtv.com/rss http://www.lefigaro.fr/rss/figaro_actualites.xml http://rss.liberation.fr/rss/latest/ http://www.leparisien.fr/une/rss.xml');
-              $("#rssitems").val('15');
-            }
-            else if (currentselection == 'russian') {
-              $('#rssinput').val('https://www.vedomosti.ru/rss/news https://meduza.io/rss/all http://static.feed.rbc.ru/rbc/logical/footer/news.rss https://russian.rt.com/rss https://lenta.ru/rss');
-              $("#rssitems").val('15');
-            }
-            else if (currentselection == 'german') {
-              $('#rssinput').val('http://www.faz.net/rss/aktuell/ http://rss.sueddeutsche.de/app/service/rss/alles/index.rss?output=rss https://www.welt.de/feeds/latest.rss https://www.tagesspiegel.de/contentexport/feed/home http://www.taz.de/!p15;rss/');
-              $("#rssitems").val('15');
-            }
-            else if (currentselection == 'tech') {
-              $('#rssinput').val('http://feeds.feedburner.com/TechCrunch https://www.technologyreview.com/topnews.rss http://feeds.arstechnica.com/arstechnica/technology-lab http://feeds.feedburner.com/venturebeat/SZYF');
-              $("#rssitems").val('15');
-            }
-            else if (currentselection == 'custom') {
+            if (currentselection == 'custom') {
               $('#rssinput').val('');
-              $("#urlsetting").show();
-              $("#advancedpane").text('– settings');
+              $('#urlsetting').show();
+              $('#advancedpane').text('– settings');
               advancedpane = 1;
             }
-
-
-
+            else if (currentselection in clientRssPresets) {
+              $('#rssinput').val(clientRssPresets[currentselection]['urls'].join(' '));
+              $('#rssitems').val(clientRssPresets[currentselection]['items']);
+              $('#urlsetting').show();
+              $('#advancedpane').text('– settings');
+              advancedpane = 1;
+            }
           });
-
-
-
 
           $('form#submitform').submit(function(){
                 $(this).find('input[type=submit]').attr('disabled', 'disabled');
                 $('#message').html('We are importing the data, this page will automatically reload. If this does not happen in 30 seconds, please, <a href="/<%= user.name %>/'+$('#context').val()+'/edit">click here</a>.');
           });
-
-
-
-
-
-
-
       });
 
-
 </script>
-
 
 <% include statsbelow %>
 </body>


### PR DESCRIPTION
There are 2 changes here:

The first moves the pre-sets in the RSS import dropdown out of the code and into the config file. This means the pre-sets can be different for different deployments (eg. someone deploying in one country may want pre-sets for that country, which may not be relevant to other users deployments). This also means the amount of code in `views/importrss.ejs` is reduced significantly.

The second change adds an option to specify a date & time when importing RSS feeds, to limit the stories imported to those later than the given date/time. Note that the date/time limit is applied _after_ the existing numeric limit, so if you wanted to ensure you imported *all* stories since a given date, you would have to ensure you provide a sufficiently high # of items limit.